### PR TITLE
chef version enforcement removed for code_generator cookbook

### DIFF
--- a/cookbooks/code_generator/metadata.rb
+++ b/cookbooks/code_generator/metadata.rb
@@ -6,6 +6,8 @@ description      'Generates the a cookbook for the cookbook-guide'
 long_description 'Generates the a cookbook for the cookbook-guide'
 version          '1.1.2'
 
+chef_version '>= 12'
+
 %w[aix amazon centos fedora freebsd debian oracle mac_os_x redhat suse opensuse opensuseleap ubuntu windows zlinux].each do |os|
   supports os
 end

--- a/cookbooks/code_generator/metadata.rb
+++ b/cookbooks/code_generator/metadata.rb
@@ -6,8 +6,6 @@ description      'Generates the a cookbook for the cookbook-guide'
 long_description 'Generates the a cookbook for the cookbook-guide'
 version          '1.1.2'
 
-chef_version '<= 12'
-
 %w[aix amazon centos fedora freebsd debian oracle mac_os_x redhat suse opensuse opensuseleap ubuntu windows zlinux].each do |os|
   supports os
 end


### PR DESCRIPTION
Otherwise, the cookbook is unusable