### PR TITLE
generated cookbooks are cookstyle compatible out-of-the-box

### DIFF
--- a/cookbooks/code_generator/files/default/spec_helper.rb
+++ b/cookbooks/code_generator/files/default/spec_helper.rb
@@ -8,12 +8,12 @@ UBUNTU_OPTS = {
   platform: 'ubuntu',
   version: '16.04',
   log_level: log_level,
-  file_cache_path: '/tmp'
+  file_cache_path: '/tmp',
 }.freeze
 
 WINDOWS_OPTS = {
   platform: 'windows',
   version: '2012R2',
   log_level: log_level,
-  file_cache_path: 'c:\chef'
+  file_cache_path: 'c:\chef',
 }.freeze

--- a/cookbooks/code_generator/templates/default/Rakefile.erb
+++ b/cookbooks/code_generator/templates/default/Rakefile.erb
@@ -16,16 +16,13 @@ namespace :style do
   FoodCritic::Rake::LintTask.new(:chef) do |t|
     t.options = {
       fail_tags: ['any'],
-      tags:[
-        '~FC005',
-        '~FC023'
-      ]
+      tags: %w(~FC005 ~FC023),
     }
   end
 end
 
 desc 'Run all style checks'
-task style: ['style:chef', 'style:ruby']
+task style: %w(style:chef style:ruby)
 
 # Rspec and ChefSpec
 desc 'Run ChefSpec examples'
@@ -50,7 +47,9 @@ namespace :integration do
 
     if run_kitchen
       Kitchen.logger = Kitchen.default_file_logger
-      @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.cloud.yml')
+      @loader = Kitchen::Loader::YAML.new(
+        project_config: './.kitchen.cloud.yml'
+      )
       config = Kitchen::Config.new(loader: @loader)
       config.instances.each do |instance|
         instance.test(:always)

--- a/cookbooks/code_generator/templates/default/rubocop.yml.erb
+++ b/cookbooks/code_generator/templates/default/rubocop.yml.erb
@@ -1,14 +1,14 @@
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: true
 Style/AccessorMethodName:
   Enabled: true
 Style/Alias:
   Enabled: true
-Style/AlignArray:
+Layout/AlignArray:
   Enabled: true
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: true
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: true
 Style/AndOr:
   Enabled: true
@@ -26,7 +26,7 @@ Style/BarePercentLiterals:
   Enabled: true
 Style/BlockComments:
   Enabled: true
-Style/BlockEndNewline:
+Layout/BlockEndNewline:
   Enabled: true
 Style/BlockDelimiters:
   Enabled: true
@@ -34,7 +34,7 @@ Style/BracesAroundHashParameters:
   Enabled: true
 Style/CaseEquality:
   Enabled: true
-Style/CaseIndentation:
+Layout/CaseIndentation:
   Enabled: true
 Style/CharacterLiteral:
   Enabled: true
@@ -48,7 +48,7 @@ Style/ClassMethods:
   Enabled: true
 Style/ClassVars:
   Enabled: true
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Enabled: true
 Style/ColonMethodCall:
   Enabled: true
@@ -56,7 +56,7 @@ Style/CommandLiteral:
   Enabled: true
 Style/CommentAnnotation:
   Enabled: true
-Style/CommentIndentation:
+Layout/CommentIndentation:
   Enabled: true
 Style/ConditionalAssignment:
   Enabled: true
@@ -68,47 +68,47 @@ Style/PreferredHashMethods:
   Enabled: true
 Style/Documentation:
   Enabled: true
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: true
 Style/DoubleNegation:
   Enabled: true
 Style/EachWithObject:
   Enabled: true
-Style/ElseAlignment:
+Layout/ElseAlignment:
   Enabled: true
 Style/EmptyElse:
   Enabled: true
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Enabled: true
-Style/EmptyLines:
+Layout/EmptyLines:
   Enabled: true
-Style/EmptyLinesAroundAccessModifier:
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: true
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: true
-Style/EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: true
-Style/EmptyLinesAroundMethodBody:
+Layout/EmptyLinesAroundMethodBody:
   Enabled: true
 Style/EmptyLiteral:
   Enabled: true
 Style/EndBlock:
   Enabled: true
-Style/EndOfLine:
+Layout/EndOfLine:
   Enabled: true
 Style/EvenOdd:
   Enabled: true
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Enabled: true
 Style/FileName:
   Enabled: true
 Style/FrozenStringLiteralComment:
   Enabled: true
-Style/InitialIndentation:
+Layout/InitialIndentation:
   Enabled: true
-Style/FirstParameterIndentation:
+Layout/FirstParameterIndentation:
   Enabled: true
 Style/FlipFlop:
   Enabled: true
@@ -128,17 +128,17 @@ Style/IfUnlessModifier:
   Enabled: true
 Style/IfWithSemicolon:
   Enabled: true
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   Enabled: true
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: true
 Style/IdenticalConditionalBranches:
   Enabled: true
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: true
-Style/IndentAssignment:
+Layout/IndentAssignment:
   Enabled: true
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: true
 Style/InfiniteLoop:
   Enabled: true
@@ -146,7 +146,7 @@ Style/Lambda:
   Enabled: true
 Style/LambdaCall:
   Enabled: true
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Enabled: true
 Style/LineEndConcatenation:
   Enabled: true
@@ -160,13 +160,13 @@ Style/ModuleFunction:
   Enabled: true
 Style/MultilineBlockChain:
   Enabled: true
-Style/MultilineBlockLayout:
+Layout/MultilineBlockLayout:
   Enabled: true
 Style/MultilineIfThen:
   Enabled: true
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: true
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: true
 Style/MultilineTernaryOperator:
   Enabled: true
@@ -194,7 +194,7 @@ Style/NumericLiterals:
   Enabled: true
 Style/OneLineConditional:
   Enabled: true
-Naming/BinaryOperatorParameterName:
+Style/OpMethod:
   Enabled: true
 Style/OptionalArguments:
   Enabled: true
@@ -228,7 +228,7 @@ Style/RedundantSelf:
   Enabled: true
 Style/RegexpLiteral:
   Enabled: true
-Style/RescueEnsureAlignment:
+Layout/RescueEnsureAlignment:
   Enabled: true
 Style/RescueModifier:
   Enabled: true
@@ -242,43 +242,43 @@ Style/SingleLineBlockParams:
   Enabled: true
 Style/SingleLineMethods:
   Enabled: true
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: true
-Style/SpaceAfterColon:
+Layout/SpaceAfterColon:
   Enabled: true
-Style/SpaceAfterComma:
+Layout/SpaceAfterComma:
   Enabled: true
-Style/SpaceAfterMethodName:
+Layout/SpaceAfterMethodName:
   Enabled: true
-Style/SpaceAfterNot:
+Layout/SpaceAfterNot:
   Enabled: true
-Style/SpaceAfterSemicolon:
+Layout/SpaceAfterSemicolon:
   Enabled: true
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: true
-Style/SpaceBeforeComma:
+Layout/SpaceBeforeComma:
   Enabled: true
-Style/SpaceBeforeComment:
+Layout/SpaceBeforeComment:
   Enabled: true
-Style/SpaceBeforeSemicolon:
+Layout/SpaceBeforeSemicolon:
   Enabled: true
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   Enabled: true
-Style/SpaceAroundBlockParameters:
+Layout/SpaceAroundBlockParameters:
   Enabled: true
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
-Style/SpaceAroundKeyword:
+Layout/SpaceAroundKeyword:
   Enabled: true
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: true
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: true
-Style/SpaceInsideRangeLiteral:
+Layout/SpaceInsideRangeLiteral:
   Enabled: true
-Style/SpaceInsideStringInterpolation:
+Layout/SpaceInsideStringInterpolation:
   Enabled: true
 Style/SpecialGlobalVars:
   Enabled: true
@@ -294,17 +294,15 @@ Style/SymbolLiteral:
   Enabled: true
 Style/SymbolProc:
   Enabled: true
-Style/Tab:
+Layout/Tab:
   Enabled: true
-Style/TrailingBlankLines:
+Layout/TrailingBlankLines:
   Enabled: true
 Style/TrailingCommaInArguments:
   Enabled: true
-Style/TrailingCommaInArrayLiteral:
+Style/TrailingCommaInLiteral:
   Enabled: true
-Style/TrailingCommaInHashLiteral:
-  Enabled: true
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Enabled: true
 Style/TrivialAccessors:
   Enabled: true
@@ -386,7 +384,7 @@ Lint/EndInMethod:
   Enabled: true
 Lint/EnsureReturn:
   Enabled: true
-Lint/Eval:
+Security/Eval:
   Enabled: true
 Lint/FloatOutOfRange:
   Enabled: true


### PR DESCRIPTION
`rubocop` file has been changed since `cookstyle` has frozen older `rubocop` version. Many `rubocop` warnings have been fixed as well.